### PR TITLE
datastore: fix namespace isolation

### DIFF
--- a/lib/datastore/entity.js
+++ b/lib/datastore/entity.js
@@ -452,7 +452,7 @@ function keyFromKeyProto(keyProto) {
   };
 
   if (keyProto.partitionId && keyProto.partitionId.namespaceId) {
-    keyOptions.namespaceId = keyProto.partitionId.namespaceId;
+    keyOptions.namespace = keyProto.partitionId.namespaceId;
   }
 
   keyProto.path.forEach(function(path, index) {


### PR DESCRIPTION
when using allocateId the namespace option was ignored due to typo
